### PR TITLE
docs(deploy): `Build output directory` should be set to `/dist`

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ You now have **Sanity** running locally on https://localhost:8080
 
 2.2.6) Select the `Sanity` repository
 
-2.2.7) Set build output directory to `/public`
+2.2.7) Set build output directory to `/dist`
 
 2.2.8) Add all the environment variables from [.env.example](.env.example)
 


### PR DESCRIPTION
<!-- CLICK "Preview" FOR INSTRUCTIONS IN A MORE READABLE FORMAT -->

## Proposed changes

Since, `npm run build` builds into `/dist` instead of `/public`. In the cloudflare page `Build and Deployment` settings, the `Build output directory` should be set to `/dist`.

## Types of changes

What types of changes does your code introduce?

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] Lint passes and build works locally with my changes
- [x] I have added necessary documentation (if appropriate)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
